### PR TITLE
Fix flaky tests in TestServerWebApp and TestViewfsWithNfs3

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
@@ -43,6 +43,8 @@ public class TestServerWebApp extends HTestCase {
     assertEquals(ServerWebApp.getDir("TestServerWebApp0", ".log.dir", "/tmp/log"), "/tmp/log");
     System.setProperty("TestServerWebApp0.log.dir", "/tmplog");
     assertEquals(ServerWebApp.getDir("TestServerWebApp0", ".log.dir", "/tmp/log"), "/tmplog");
+    System.clearProperty("TestServerWebApp0.home.dir");
+    System.clearProperty("TestServerWebApp0.log.dir");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/test/java/org/apache/hadoop/hdfs/nfs/nfs3/TestViewfsWithNfs3.java
@@ -326,5 +326,7 @@ public class TestViewfsWithNfs3 {
     statusAfterRename =
         nn1.getRpcServer().getFileInfo("/user1/renameSingleNN");
     Assert.assertEquals(statusAfterRename, null);
+    testNfsRename(fromHandle, "renameSingleNNSucess",
+        fromHandle, "renameSingleNN", Nfs3Status.NFS3_OK);
   }
 }


### PR DESCRIPTION
The following two tests are not idempotent and would fail when run twice in the same test run:
-- org.apache.hadoop.lib.servlet.TestServerWebApp.getHomeDir
-- org.apache.hadoop.hdfs.nfs.nfs3.TestViewfsWithNfs3.testNfsRenameSingleNN

This PR proposes fixes to these two tests so that they become idempotent.

Details for TestServerWebApp.getHomeDir
-----------------
Running TestServerWebApp.getHomeDir twice would result in the second run failing with the following error:
```
TestServerWebApp.getHomeDir:43 expected:</tmp[]log> but was:</tmp[/]log>
```
The root cause of this is that in the first test run, some system properties are set up. The system properties are not cleaned up when the test is done, causing an assertion in the second run to fail.

The fix is to clear the system properties when the test finishes.

Details for TestViewfsWithNfs3.testNfsRenameSingleNN
-----------------
Running TestViewfsWithNfs3.testNfsRenameSingleNN twice would result in the second run failing with the a NullPointer exception:
```
[ERROR] Errors:
[ERROR]   TestViewfsWithNfs3.testNfsRenameSingleNN:317 NullPointer
```
The reason for this is that the "/user1/renameSingleNN" file is created in setup(), but gets renamed in the first run of  testNfsRenameSingleNN. When the second run of testNfsRenameSingleNN tries to get info of the file by its original name, it returns a NullPointer since the file no longer exists.
The fix for this is to rename the file back to the original when the test is done.

With the proposed fixes, each test pass when running twice.

