### PR TITLE
Clear system properties in TestServerWebApp.getHomeDir()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
@@ -43,6 +43,8 @@ public class TestServerWebApp extends HTestCase {
     assertEquals(ServerWebApp.getDir("TestServerWebApp0", ".log.dir", "/tmp/log"), "/tmp/log");
     System.setProperty("TestServerWebApp0.log.dir", "/tmplog");
     assertEquals(ServerWebApp.getDir("TestServerWebApp0", ".log.dir", "/tmp/log"), "/tmplog");
+    System.clearProperty("TestServerWebApp0.home.dir");
+    System.clearProperty("TestServerWebApp0.log.dir");
   }
 
   @Test


### PR DESCRIPTION
The test `org.apache.hadoop.lib.servlet.TestServerWebApp.getHomeDir` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests.It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Details
---
Running `TestServerWebApp.getHomeDir` twice would result in the second run failing with the following error:
```
TestServerWebApp.getHomeDir:43 expected:</tmp[]log> but was:</tmp[/]log>
```
The root cause of this is that in the first test run, some system properties are set up. The system properties are not cleaned up when the test is done, causing an assertion in the second run to fail.

The fix is to clear the system properties when the test finishes.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
