### PR TITLE
Clear the fileMap in JHEventHandlerForSigtermTest

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEventHandler.java
@@ -1119,6 +1119,7 @@ class JHEvenHandlerForTest extends JobHistoryEventHandler {
 class JHEventHandlerForSigtermTest extends JobHistoryEventHandler {
   public JHEventHandlerForSigtermTest(AppContext context, int startCount) {
     super(context, startCount);
+    JobHistoryEventHandler.fileMap.clear();
   }
 
   public void addToFileMap(JobId jobId) {


### PR DESCRIPTION
The test `org.apache.hadoop.mapreduce.jobhistory.TestJobHistoryEventHandler.testSigTermedFunctionality` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Details
---
Running `TestJobHistoryEventHandler.testSigTermedFunctionality` twice would result in the second run failing due to `NullPointerException`shown in the following:
```
java.lang.NullPointerException
	at org.apache.hadoop.mapreduce.jobhistory.JobHistoryEventHandler.serviceStop(JobHistoryEventHandler.java:460)
	at org.apache.hadoop.service.AbstractService.stop(AbstractService.java:221)
	at org.apache.hadoop.mapreduce.jobhistory.TestJobHistoryEventHandler.testSigTermedFunctionality(TestJobHistoryEventHandler.java:933)
```
The root cause of this is that running `TestJobHistoryEventHandler.testSigTermedFunctionality` results in some entries to be added to the static `JobHistoryEventHandler.fileMap`. The entries in the `fileMap` are not cleaned up when the test is done, resulting in a `NullPointerException` in the second run as the stale object(added in the first run) in the `fileMap` is accessed.

The fix is to clear the `fileMap` at the end of the constructor of `JHEventHandlerForSigtermTest`. Note that this has already been done in the `JHEvenHandlerForTest `, which is used by the other tests in the `TestJobHistoryEventHandler`. The same clean up needs to take place in `JHEventHandlerForSigtermTest`.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
